### PR TITLE
implement TSing singleton type in typechecking and extraction

### DIFF
--- a/src/AST.hs
+++ b/src/AST.hs
@@ -260,6 +260,7 @@ data TyX =
     | TSS NameExp NameExp -- Singleton type
     | TAdmit -- return type of admit 
     | TExistsIdx (Bind IdxVar Ty) -- Label of which idx I am is adversary
+    | TSing AExpr -- Singleton type
     deriving (Show, Generic, Typeable)
 
 

--- a/src/Extraction/ConcreteAST.hs
+++ b/src/Extraction/ConcreteAST.hs
@@ -39,6 +39,7 @@ data CTy =
     | CTDH_PK NameExp -- Singleton type
     | CTEnc_PK NameExp -- Singleton type
     | CTSS NameExp NameExp -- Singleton type
+    | CTSing String -- hex constant string
     deriving (Show, Generic, Typeable)
 
 instance Alpha CTy
@@ -81,6 +82,10 @@ concretifyTy t =
     TExistsIdx it -> do
       (_, t) <- unbind it
       concretifyTy t
+    TSing a -> do
+      case a^.val of
+        AEHex s -> return $ CTSing s
+        _ -> error "concretifyTy on TSing with non-hex string"
 
 doConcretifyTy :: Ty -> CTy
 doConcretifyTy = runFreshM . concretifyTy
@@ -213,6 +218,8 @@ instance OwlPretty CTy where
             owlpretty "encpk(" <> owlpretty n <> owlpretty ")"
     owlpretty (CTSS n m) =
             owlpretty "shared_secret(" <> owlpretty n <> owlpretty ", " <> owlpretty m <> owlpretty ")"
+    owlpretty (CTSing a) =
+            owlpretty "Sing(" <> owlpretty a <> owlpretty ")"
     -- owlpretty (CTUnion t1 t2) =
     --     owlpretty "Union<" <> owlpretty t1 <> owlpretty "," <> owlpretty t2 <> owlpretty ">"
 

--- a/src/Extraction/ExtractionBase.hs
+++ b/src/Extraction/ExtractionBase.hs
@@ -106,6 +106,7 @@ defaultHMACMode :: HMACMode
 defaultHMACMode = Sha512
 data Layout =
   LBytes Int -- number of bytes
+  | LHexConst String -- hex constant
   | LUnboundedBytes -- Bytes without statically knowable length. Restricted to be the last field in a struct.
   | LStruct String [(String, Layout)] -- field, layout
   | LEnum String (M.Map String (Int, Maybe Layout)) -- finite map from tags to (tag byte, layout)
@@ -594,6 +595,8 @@ hexStringToByteList (h1 : h2 : t) = do
     t' <- hexStringToByteList t
     return $ owlpretty "0x" <> owlpretty h1 <> owlpretty h2 <> owlpretty "u8," <+> t'
 hexStringToByteList _ = throwError OddLengthHexConst
+
+
 
 resolveANF :: M.Map String (a, Maybe AExpr) -> AExpr -> ExtractionMonad AExpr
 resolveANF binds a = do

--- a/src/Parse.hs
+++ b/src/Parse.hs
@@ -28,7 +28,7 @@ owlStyle   = P.LanguageDef
                 , P.identLetter    = alphaNum <|> oneOf "_'?"
                 , P.opStart        = oneOf ":!#$%&*+./<=>?@\\^|-~"
                 , P.opLetter       = oneOf ":!#$%&*+./<=>?@\\^|-~"
-                , P.reservedNames  = ["adv",  "bool", "Option", "name", "Name", "enckey",  "st_aead", "nonce_pattern", "mackey", "sec", "st_aead_enc", "st_aead_dec", "let", "DH", "nonce", "if", "then", "else", "enum", "Data", "sigkey", "type", "Unit", "Lemma", "random_oracle", "return", "corr", "RO", "debug", "assert",  "assume", "admit", "ensures", "true", "false", "True", "False", "call", "static", "corr_case", "false_elim", "union_case", "exists", "get",  "getpk", "getvk", "pack", "def", "Union", "pkekey", "pke_sk", "pke_pk", "label", "aexp", "type", "idx", "table", "lookup", "write", "unpack", "to", "include", "maclen",  "begin", "end", "module", "aenc", "adec", "pkenc", "pkdec", "mac", "mac_vrfy", "sign", "vrfy", "prf",  "PRF", "forall", "bv", "pcase", "choose_idx", "crh_lemma", "ro", "is_constant_lemma", "strict", "aad"]
+                , P.reservedNames  = ["adv",  "bool", "Option", "name", "Name", "enckey",  "st_aead", "nonce_pattern", "mackey", "sec", "st_aead_enc", "st_aead_dec", "let", "DH", "nonce", "if", "then", "else", "enum", "Data", "sigkey", "type", "Unit", "Lemma", "random_oracle", "return", "corr", "RO", "debug", "assert",  "assume", "admit", "ensures", "true", "false", "True", "False", "call", "static", "corr_case", "false_elim", "union_case", "exists", "get",  "getpk", "getvk", "pack", "def", "Union", "pkekey", "pke_sk", "pke_pk", "label", "aexp", "type", "idx", "table", "lookup", "write", "unpack", "to", "include", "maclen",  "begin", "end", "module", "aenc", "adec", "pkenc", "pkdec", "mac", "mac_vrfy", "sign", "vrfy", "prf",  "PRF", "forall", "bv", "pcase", "choose_idx", "crh_lemma", "ro", "is_constant_lemma", "strict", "aad", "Sing"]
                 , P.reservedOpNames= ["(", ")", "->", ":", "=", "==", "!", "<=", "!<=", "!=", "*", "|-", "+x"]
                 , P.caseSensitive  = True
                 }
@@ -186,6 +186,13 @@ parseTyTerm =
     (parseSpanned $ do
         reserved "Unit"
         return $ TUnit)
+    <|>
+    (parseSpanned $ do
+        reserved "Sing"
+        symbol "("
+        a <- parseAExpr
+        symbol ")"
+        return $ TSing a)
     <|>
     (parseSpanned $ do
         reserved "Lemma"

--- a/src/Pass/PathResolution.hs
+++ b/src/Pass/PathResolution.hs
@@ -359,6 +359,9 @@ resolveTy e = do
                       t1' <- resolveTy t1
                       t2' <- resolveTy t2
                       return $ TCase p' t1' t2'
+                  TSing a -> do
+                      a' <- resolveAExpr a
+                      return $ TSing a'
 
 
 resolveNameExp :: NameExp -> Resolve NameExp

--- a/src/Pretty.hs
+++ b/src/Pretty.hs
@@ -137,6 +137,8 @@ instance  OwlPretty TyX where
         owlpretty "exists" <+> i <> owlpretty "." <+> t
     owlpretty (TUnion t1 t2) =
         owlpretty "Union<" <> owlpretty t1 <> owlpretty "," <> owlpretty t2 <> owlpretty ">"
+    owlpretty (TSing a) =
+        owlpretty "Sing(" <> owlpretty a <> owlpretty ")"
 
 instance  OwlPretty Quant where
     owlpretty Forall = owlpretty "forall"

--- a/src/SMT.hs
+++ b/src/SMT.hs
@@ -423,7 +423,10 @@ smtTy t =
                       Just t -> smtTy t
                       Nothing -> return $ SAtom "Unit"
                 return $ sEnumType vts
-
+      TSing a -> do
+          -- In SMT, we interpret (TSing a) as (x:Data{x == a})
+          v <- interpretAExp a
+          return $ sRefined (SAtom "Data") $ \x -> x `sEq` v 
             
 sIterPair :: [SExp]  -> SExp
 sIterPair [] = error "Got empty list in sIterPair"

--- a/src/TypingBase.hs
+++ b/src/TypingBase.hs
@@ -1187,6 +1187,10 @@ coveringLabel' t =
           l <- local (over (inScopeIndices) $ insert x IdxGhost) $ coveringLabel' t
           let l1 = mkSpanned $ LRangeIdx $ bind x l
           return $ joinLbl advLbl l1
+      TSing a -> do
+          t <- inferAExpr a
+          coveringLabel' t
+          
 
 tyInfo :: Ty -> OwlDoc
 tyInfo t = 

--- a/tests/success/singleton-type.owl
+++ b/tests/success/singleton-type.owl
@@ -1,0 +1,24 @@
+locality alice
+locality bob
+
+name n: nonce @ alice
+corr adv ==> [n]
+
+struct s {
+    _tag : Sing(0x00000001),
+    _message : Data<adv> | |nonce| |
+}
+
+def alice_main() @ alice : Unit =
+    let n = get(n) in
+    let t = 0x00000001 in
+    let sv = s(t, n) in
+    output sv to endpoint(bob)
+
+def bob_main() @ bob : Unit =
+    input i in
+    parse i as s(t, n) in {
+    assert(t == 0x00000001);
+    ()
+    } otherwise ()
+    


### PR DESCRIPTION
As we discussed before I implemented a `TSing` singleton type that is used for constants in message formats. I added a small test case `singleton-type.owl` which passes typechecking and extraction.

Questions:
- In SMT I extract `TSing a` to a type like `(x:Data{x == a})`, since we ought to know that the singleton type value is exactly the value we expect. Is this reasonable?
- In `stripTy` in `Typing.hs` I wasn't sure exactly what logic needs to be implemented, since I'm somewhat unsure of the purpose of that function. Some of the other cases do something differently if the variable `x` is free in the type, but it seems like that shouldn't be the case for `TSing`?
- Do I additionally need to generate length refinements for `TSing`? Currently `TSing (AEHex s)` will get no length refinement in the typechecker.