### PR TITLE
PRF extraction

### DIFF
--- a/extraction/preamble.rs
+++ b/extraction/preamble.rs
@@ -95,4 +95,10 @@ pub fn debug_print_bytes(x: &[u8]) {
     println!("debug_print_bytes: {:?}", x);
 }
 
+pub fn ghost_unit() -> (res: Ghost<()>)
+    ensures res == Ghost(())
+{
+    Ghost(())
+}
+
 } // verus!

--- a/extraction/preamble.rs
+++ b/extraction/preamble.rs
@@ -45,7 +45,8 @@ pub open const spec fn HMAC_MODE() -> owl_hmac::Mode { crate::owl_hmac::Mode::Sh
 pub const fn hmac_mode() -> (r:owl_hmac::Mode) ensures r == HMAC_MODE() { crate::owl_hmac::Mode::Sha512 }
 pub open const spec fn MACKEY_SIZE() -> usize { owl_hmac::spec_key_size(HMAC_MODE()) }
 pub const fn mackey_size() -> (r:usize) ensures r == MACKEY_SIZE() { owl_hmac::key_size(hmac_mode()) }
-
+pub open const spec fn KDFKEY_SIZE() -> usize { owl_hkdf::spec_kdfkey_size() }
+pub const fn kdfkey_size() -> (r:usize) ensures r == KDFKEY_SIZE() { owl_hkdf::kdfkey_size() }
 
 #[verifier(external_type_specification)]
 #[verifier(external_body)]

--- a/extraction/src/execlib.rs
+++ b/extraction/src/execlib.rs
@@ -173,11 +173,11 @@ pub exec fn owl_dh_combine(pubkey: &[u8], privkey: &[u8]) -> (ss: Arc<Vec<u8>>)
 }
 
 #[verifier(external_body)]
-pub exec fn owl_extract_expand_to_len(len: usize, salt: &[u8], ikm: &[u8]) -> (h: Arc<Vec<u8>>) 
-    ensures h.dview() == kdf(len.dview(), salt.dview(), ikm.dview()),
+pub exec fn owl_extract_expand_to_len(len: usize, salt: &[u8], ikm: &[u8], info: &[u8]) -> (h: Arc<Vec<u8>>) 
+    ensures h.dview() == kdf(len.dview(), salt.dview(), ikm.dview(), info.dview()),
             h.dview().len() == len
 {
-    arc_new(owl_hkdf::extract_expand_to_len(ikm, salt, len))
+    arc_new(owl_hkdf::extract_expand_to_len(ikm, salt, info, len))
 }
 
 #[verifier(external_body)]

--- a/extraction/src/owl_dhke.rs
+++ b/extraction/src/owl_dhke.rs
@@ -4,7 +4,7 @@ use vstd::prelude::*;
 verus! {
 
 #[verifier(external_body)]
-pub fn gen_ecdh_key_pair() -> (_: (Vec<u8>, Vec<u8>)) {
+pub fn gen_ecdh_key_pair() -> (Vec<u8>, Vec<u8>) {
     let mut rng = rand::thread_rng();
     let secret = StaticSecret::new(&mut rng);
     let public = PublicKey::from(&secret);

--- a/extraction/src/owl_hkdf.rs
+++ b/extraction/src/owl_hkdf.rs
@@ -4,6 +4,10 @@ use vstd::prelude::*;
 
 verus! {
 
+pub open spec fn spec_kdfkey_size() -> usize { 32 }
+pub const fn kdfkey_size() -> (r:usize) ensures r == spec_kdfkey_size() { 32 }
+
+
 #[verifier(external_body)]
 pub fn extract_expand_to_len(ikm: &[u8], salt: &[u8], info: &[u8], len: usize) -> Vec<u8> {
     let h = Hkdf::<Sha256>::new(Some(salt), ikm);

--- a/extraction/src/owl_hkdf.rs
+++ b/extraction/src/owl_hkdf.rs
@@ -7,6 +7,10 @@ verus! {
 pub open spec fn spec_kdfkey_size() -> usize { 32 }
 pub const fn kdfkey_size() -> (r:usize) ensures r == spec_kdfkey_size() { 32 }
 
+#[verifier(external_body)]
+pub fn gen_rand_kdf_key() -> Vec<u8> {
+    crate::owl_util::gen_rand_bytes(kdfkey_size())
+}
 
 #[verifier(external_body)]
 pub fn extract_expand_to_len(ikm: &[u8], salt: &[u8], info: &[u8], len: usize) -> Vec<u8> {

--- a/extraction/src/owl_hkdf.rs
+++ b/extraction/src/owl_hkdf.rs
@@ -5,10 +5,10 @@ use vstd::prelude::*;
 verus! {
 
 #[verifier(external_body)]
-pub fn extract_expand_to_len(ikm: &[u8], salt: &[u8], len: usize) -> Vec<u8> {
+pub fn extract_expand_to_len(ikm: &[u8], salt: &[u8], info: &[u8], len: usize) -> Vec<u8> {
     let h = Hkdf::<Sha256>::new(Some(salt), ikm);
     let mut okm = vec![0u8; len];
-    h.expand(&[], &mut okm).expect("failed to expand");
+    h.expand(info, &mut okm).expect("failed to expand");
     okm
 }
 

--- a/extraction/src/owl_pke.rs
+++ b/extraction/src/owl_pke.rs
@@ -14,7 +14,7 @@ verus! {
 pub const PRIVATE_KEY_BITS: usize = 2048;
 
 #[verifier(external_body)]
-pub fn gen_rand_keys() -> (_:(Vec<u8>, Vec<u8>)) {
+pub fn gen_rand_keys() -> (Vec<u8>, Vec<u8>) {
     let mut rng = rand::thread_rng();
     let privkey = RsaPrivateKey::new(&mut rng, PRIVATE_KEY_BITS).unwrap();
     let pubkey = RsaPublicKey::from(&privkey);

--- a/extraction/src/speclib.rs
+++ b/extraction/src/speclib.rs
@@ -252,6 +252,12 @@ pub open spec fn andb(x: bool, y: bool) -> bool
     x && y
 }
 
+pub open spec fn notb(x: bool) -> bool
+{
+    !x
+}
+
+
 pub open spec fn length(x: Seq<u8>) -> usize
     recommends x.len() < usize::MAX
 {

--- a/extraction/src/speclib.rs
+++ b/extraction/src/speclib.rs
@@ -197,7 +197,7 @@ pub closed spec(checked) fn dh_combine(pubkey: Seq<u8>, privkey: Seq<u8>) -> (ss
 { unimplemented!() }
 
 #[verifier(external_body)]
-pub closed spec(checked) fn kdf(len: usize, salt: Seq<u8>, x: Seq<u8>) -> (h: Seq<u8>)
+pub closed spec(checked) fn kdf(len: usize, salt: Seq<u8>, ikm: Seq<u8>, info: Seq<u8>) -> (h: Seq<u8>)
 { unimplemented!() }
 
 #[verifier(external_body)]

--- a/extraction/src/speclib.rs
+++ b/extraction/src/speclib.rs
@@ -264,6 +264,11 @@ pub open spec fn length(x: Seq<u8>) -> usize
     x.len() as usize
 }
 
+pub open spec fn spec_ghost_unit() -> Ghost<()>
+{
+    Ghost(())
+}
+
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -498,6 +503,17 @@ pub mod itree {
 
     #[allow(unused_macros)]
     #[macro_export]
+    macro_rules! owl_call_ret_unit {
+        [$($tail:tt)*] => {
+            ::builtin_macros::verus_exec_macro_exprs!{
+                owl_call_internal!(res, res.dview(), $($tail)*)
+            }
+        };
+    }
+
+
+    #[allow(unused_macros)]
+    #[macro_export]
     macro_rules! owl_call_ret_option {
         [$($tail:tt)*] => {
             ::builtin_macros::verus_exec_macro_exprs!{
@@ -630,7 +646,7 @@ pub mod itree {
         ($mut_state:ident, $mut_type:ident, 
             case ($parser:ident($a:ident)) { $(| $pattern:pat => { $($branch:tt)* },)* otherwise ($($otw:tt)*)}) => 
         { verus_proof_expr!{
-            if let Some(parseval) = $parser($a.as_seq()) {
+            if let Some(parseval) = $parser($a) { // TODO check whether we need .as_seq() here? Causes typechecking issues?
                 match parseval {
                     $($pattern => { owl_spec!($mut_state, $mut_type, $($branch)*) })*
                 }

--- a/src/Extraction/ConcreteAST.hs
+++ b/src/Extraction/ConcreteAST.hs
@@ -95,6 +95,7 @@ data CExpr =
     | CInput (Bind (DataVar, EndpointVar) CExpr)
     | COutput AExpr (Maybe Endpoint)
     | CLet CExpr (Maybe AExpr) (Bind DataVar CExpr)
+    | CLetGhost (Bind DataVar CExpr)
     | CBlock CExpr -- Boundary for scoping; introduced by { }
     | CIf AExpr CExpr CExpr
     | CRet AExpr
@@ -121,7 +122,8 @@ concretify e =
         EOutput a eo -> return $ COutput a eo
         ELet e1 tyann oanf _ xk | isGhostTyAnn tyann -> do
             let (x, k) = unsafeUnbind xk   
-            concretify k
+            k' <- concretify k
+            return $ CLetGhost (bind x k')
         ELet e1 tyann oanf _ xk -> do
             e1' <- concretify e1
             let (x, k) = unsafeUnbind xk
@@ -196,8 +198,9 @@ concretify e =
         ESetOption _ _ e -> concretify e
         ELetGhost _ _ xk -> do
             -- TODO check this
-            let (_, k) = unsafeUnbind xk
-            concretify k
+            let (x, k) = unsafeUnbind xk
+            k' <- concretify k
+            return $ CLetGhost (bind x k')
         ECorrCaseNameOf _ _ k -> concretify k
         -- _ -> error $ "Concretify on " ++ show (owlpretty e)
 
@@ -270,3 +273,6 @@ instance OwlPretty CExpr where
     owlpretty (CParse ae t ok bindpat) = 
         let (pats, k) = owlprettyBind bindpat in
         owlpretty "parse" <+> owlpretty ae <+> owlpretty "as" <+> owlpretty t <> parens pats <+> owlpretty "otherwise" <+> owlpretty ok <+> owlpretty "in" <> line <> k
+    owlpretty (CLetGhost xk) =
+        let (x, k) = owlprettyBind xk in
+        owlpretty "letghost" <+> x <+> owlpretty "in" <> line <> k

--- a/src/Extraction/ConcreteAST.hs
+++ b/src/Extraction/ConcreteAST.hs
@@ -194,6 +194,11 @@ concretify e =
         EIncCtr p idxs -> return $ CIncCtr p idxs
         EGetCtr p idxs -> return $ CGetCtr p idxs
         ESetOption _ _ e -> concretify e
+        ELetGhost _ _ xk -> do
+            -- TODO check this
+            let (_, k) = unsafeUnbind xk
+            concretify k
+        ECorrCaseNameOf _ _ k -> concretify k
         -- _ -> error $ "Concretify on " ++ show (owlpretty e)
 
 doConcretify :: Expr -> CExpr
@@ -223,6 +228,8 @@ instance OwlPretty CTy where
             owlpretty "shared_secret(" <> owlpretty n <> owlpretty ", " <> owlpretty m <> owlpretty ")"
     owlpretty (CTHex a) =
             owlpretty "Const(" <> owlpretty "0x" <> owlpretty a <> owlpretty ")"
+    owlpretty CTGhost = 
+            owlpretty "Ghost"
     -- owlpretty (CTUnion t1 t2) =
     --     owlpretty "Union<" <> owlpretty t1 <> owlpretty "," <> owlpretty t2 <> owlpretty ">"
 

--- a/src/Extraction/Extraction.hs
+++ b/src/Extraction/Extraction.hs
@@ -108,6 +108,7 @@ layoutCTy u (CTSS n n') = do
     let l = dhSize
     return $ LBytes l
 layoutCTy u (CTHex s) = return $ LHexConst s
+layoutCTy _ CTGhost = throwError $ GhostInExec "layoutCTy of ghost"
 
 isNestable :: Layout -> Bool
 isNestable (LBytes _) = True
@@ -442,49 +443,58 @@ extractCryptOp binds op owlArgs = do
     let preArgs = foldl (\p (_,s,_) -> p <> s) (owlpretty "") argsPretties
     let args = map (\(r, _, p) -> (r, show p)) argsPretties
     (rt, preCryptOp, str) <- case (op, args) of
-        -- (CHash ((ropath,_,_):_) i, args) -> do 
-        --    -- Typechecking checks that the list of hints is non-empty and that all hints point to consistent return type name kinds,
-        --    -- so we can just use the first one to calculate the length to extract to
-        --    roname <- flattenPath ropath
-        --    orcls <- use oracles
-        --    (outLen, sliceIdxs) <- case orcls M.!? roname of
-        --        Nothing -> throwError $ TypeError $ "unrecognized random oracle " ++ roname
-        --        Just (outLen', sliceIdxs) -> do
-        --            outLen'' <- mapM printLenConst outLen'
-        --            return (intercalate "+" outLen'', sliceIdxs)
-        --    (start, end) <- case sliceIdxs M.!? i of
-        --        Nothing -> throwError $ TypeError $ "bad index " ++ show i ++ " to random oracle " ++ roname
-        --        Just (s', e', _) -> do
-        --            s'' <- mapM printLenConst s'
-        --            e'' <- mapM printLenConst e'
-        --            return (intercalate "+" s'', intercalate "+" e'')
-        --    -- Check if we have already evaluated this RO; if not, evaluate it
-        --    resolvedArgs <- mapM (resolveANF binds) owlArgs
-        --    oopt <- lookupHashCall (roname, resolvedArgs)
-        --    (genOrcl, orclName) <- case oopt of
-        --        Just (Rc VecU8, name) -> return (pretty "", name)
-        --        Nothing -> do
-        --            rovar' <- fresh . s2n $ roname
-        --            let rovar = rustifyName . show $ rovar'
-        --            hashCalls %= (:) ((roname, resolvedArgs), (Rc VecU8, rovar))
-        --            orclArgs <- case args of
-        --                    [ikm] -> return [(Number, outLen), (Rc VecU8, "self.salt"), ikm]
-        --                    [salt, ikm] -> return [(Number, outLen), salt, ikm]
-        --                    _ -> throwError $ TypeError "unsupported random-oracle argument pattern"
-        --            let genOrcl = 
-        --                    owlpretty "let" <+> owlpretty rovar <+> owlpretty "=" <+>
-        --                    owlpretty (printOwlOp "owl_extract_expand_to_len" orclArgs) <> owlpretty ";"
-        --            return (genOrcl, rovar)
-        --        _ -> throwError $ ErrSomethingFailed "precomputed hash value has wrong type"
-        --    let sliceOrcl = rcNew <> parens (
-        --                        owlpretty "slice_to_vec" <> parens (
-        --                            owlpretty "slice_subrange" <> parens (
-        --                                owlpretty "vec_as_slice" <> parens (owlpretty "&*" <> owlpretty orclName) <> comma <+>
-        --                                owlpretty start <> comma <+> owlpretty end
-        --                            )
-        --                        )
-        --                    )
-        --    return (Rc VecU8, genOrcl, sliceOrcl)
+        (CKDF _ _ nks nkidx, [salt, ikm, info]) -> do
+            
+            -- Typechecking checks that the list of hints is non-empty and that all hints point to consistent return type name kinds,
+            -- so we can just use the first one to calculate the length to extract to
+            --    roname <- flattenPath ropath
+            --    orcls <- use oracles
+            --    (outLen, sliceIdxs) <- case orcls M.!? roname of
+            --        Nothing -> throwError $ TypeError $ "unrecognized random oracle " ++ roname
+            --        Just (outLen', sliceIdxs) -> do
+            --            outLen'' <- mapM printLenConst outLen'
+            --            return (intercalate "+" outLen'', sliceIdxs)
+            --    (start, end) <- case sliceIdxs M.!? i of
+            --        Nothing -> throwError $ TypeError $ "bad index " ++ show i ++ " to random oracle " ++ roname
+            --        Just (s', e', _) -> do
+            --            s'' <- mapM printLenConst s'
+            --            e'' <- mapM printLenConst e'
+            --            return (intercalate "+" s'', intercalate "+" e'')
+            -- TODO we can just use `resolvedArgs` to look up the hash call, or just add the nks, we don't need the ghost args?
+            (outLen, sliceIdxs) <- do
+                (outLen', sliceIdxs) <- makeKdfSliceMap nks
+                outLen'' <- mapM printLenConst outLen'
+                return (intercalate "+" outLen'', sliceIdxs)
+            (start, end) <- case sliceIdxs M.!? nkidx of
+                Nothing -> throwError $ TypeError $ "bad index " ++ show nkidx ++ " to kdf with return type " ++ show nks
+                Just (s', e', _) -> do
+                    s'' <- mapM printLenConst s'
+                    e'' <- mapM printLenConst e'
+                    return (intercalate "+" s'', intercalate "+" e'')
+            -- Check if we have already evaluated this RO; if not, evaluate it
+            resolvedArgs <- mapM (resolveANF binds) owlArgs
+            oopt <- lookupKdfCall nks resolvedArgs
+            (genOrcl, orclName) <- case oopt of
+                Just (Rc VecU8, name) -> return (pretty "", name)
+                Nothing -> do
+                    rovar' <- fresh . s2n $ "kdfval"
+                    let rovar = rustifyName . show $ rovar'
+                    kdfCalls %= (:) ((nks, resolvedArgs), (Rc VecU8, rovar))
+                    let kdfArgs = [(Number, outLen), salt, ikm, info]
+                    let genOrcl = 
+                            owlpretty "let" <+> owlpretty rovar <+> owlpretty "=" <+>
+                            owlpretty (printOwlOp "owl_extract_expand_to_len" kdfArgs) <> owlpretty ";"
+                    return (genOrcl, rovar)
+                _ -> throwError $ ErrSomethingFailed "precomputed hash value has wrong type"
+            let sliceOrcl = rcNew <> parens (
+                                owlpretty "slice_to_vec" <> parens (
+                                    owlpretty "slice_subrange" <> parens (
+                                        owlpretty "vec_as_slice" <> parens (owlpretty "&*" <> owlpretty orclName) <> comma <+>
+                                        owlpretty start <> comma <+> owlpretty end
+                                    )
+                                )
+                            )
+            return (Rc VecU8, genOrcl, sliceOrcl)
         -- (CPRF s, _) -> do throwError $ ErrSomethingFailed $ "TODO implement crypto op: " ++ show op
         (CAEnc, [k, x]) -> do 
             typeAnnot <- do
@@ -938,7 +948,7 @@ extractDef owlName loc owlArgs owlRetTy owlBody isMain = do
         intoOk rustExpr = owlpretty "let res_inner = {" <> line <> line <> rustExpr <> line <> line <> owlpretty "};" <> line <> owlpretty "Ok(res_inner)"
         genMainWrapper owlName lname execRetTy specRetTy = 
             owlpretty "#[verifier(external_body)] pub exec fn" <+> owlpretty (rustifyName owlName) <> owlpretty "_wrapper" <> 
-            parens (owlpretty "&self, s: &mut" <+> owlpretty (stateName lname)) <> owlpretty "->" <> parens (owlpretty "_:" <+> owlpretty execRetTy) <> braces (line <>
+            parens (owlpretty "&self, s: &mut" <+> owlpretty (stateName lname)) <> owlpretty "->" <> owlpretty execRetTy <> braces (line <>
                 owlpretty "let tracked dummy_tok: ITreeToken<(), Endpoint> = ITreeToken::<(), Endpoint>::dummy_itree_token();" <> line <>
                 owlpretty "let tracked (Tracked(call_token), _) = split_bind(dummy_tok," <+>  owlpretty owlName <> owlpretty "_spec(*self, *s)" <> owlpretty ");" <> line <>
 

--- a/src/Extraction/Extraction.hs
+++ b/src/Extraction/Extraction.hs
@@ -991,6 +991,7 @@ nameInit s nt = case nt^.val of
     NT_StAEAD {} -> 
                 return $ owlpretty "let" <+> owlpretty (rustifyName s) <+> owlpretty "=" <+> owlpretty "owl_aead::gen_rand_key(cipher());"
     NT_MAC _ -> return $ owlpretty "let" <+> owlpretty (rustifyName s) <+> owlpretty "=" <+> owlpretty "owl_hmac::gen_rand_key(&hmac_mode());"
+    NT_KDF _ _ -> return $ owlpretty "let" <+> owlpretty (rustifyName s) <+> owlpretty "=" <+> owlpretty "owl_hkdf::gen_rand_kdf_key();"
     NT_PKE _ -> return $ owlpretty "let" <+> (parens . hsep . punctuate comma . map owlpretty $ [rustifyName s, "pk_" ++ rustifyName s]) <+> owlpretty "=" <+> owlpretty "owl_pke::gen_rand_keys();"
     NT_Sig _ -> return $ owlpretty "let" <+> (parens . hsep . punctuate comma . map owlpretty $ [rustifyName s, "pk_" ++ rustifyName s]) <+> owlpretty "=" <+> owlpretty "owl_pke::gen_rand_keys();"
     NT_DH ->    return $ owlpretty "let" <+> (parens . hsep . punctuate comma . map owlpretty $ [rustifyName s, "pk_" ++ rustifyName s]) <+> owlpretty "=" <+> owlpretty "owl_dhke::gen_ecdh_key_pair();"

--- a/src/Extraction/ExtractionBase.hs
+++ b/src/Extraction/ExtractionBase.hs
@@ -429,6 +429,10 @@ initFuncs =
             ("andb", (\args -> case args of
                 [(Bool,x), (Bool,y)] -> return $ (Bool, x ++ " && " ++ y)
                 _ -> throwError $ TypeError $ "got wrong args for andb"
+            )),
+            ("notb", (\args -> case args of
+                [(Bool,x)] -> return $ (Bool, "! " ++ x)
+                _ -> throwError $ TypeError $ "got wrong args for andb"
             ))
         ] 
 

--- a/src/Extraction/ExtractionBase.hs
+++ b/src/Extraction/ExtractionBase.hs
@@ -321,6 +321,9 @@ counterSize = 8 -- TODO This is specific to Wireguard---should be a param
 crhSize :: Int
 crhSize = 32 -- TODO This is specific to Wireguard
 
+kdfKeySize :: Int
+kdfKeySize = 32 -- TODO This is specific to Wireguard
+
 initLenConsts :: M.Map String Int
 initLenConsts = M.fromList [
         (rustifyName "signature", 256),
@@ -331,6 +334,7 @@ initLenConsts = M.fromList [
         (rustifyName "pke_sk", pkeKeySize),
         (rustifyName "pke_pk", pkePubKeySize),
         (rustifyName "sigkey", sigKeySize),
+        (rustifyName "kdfkey", kdfKeySize),
         (rustifyName "vk", vkSize),
         (rustifyName "DH", dhSize),
         (rustifyName "group", dhSize),
@@ -661,9 +665,9 @@ makeKdfSliceMap :: [NameKind] -> ExtractionMonad ([String], M.Map Int ([String],
 makeKdfSliceMap nks = do
     (totLen, sliceMap) <- foldM (\(t, m) (i, nk) -> do
             (rtstr, len) <- case nk of
-                -- NK_KDF -> do
-                --     l <- useKdfKeySize
-                --     return ("kdf", l)
+                NK_KDF -> do
+                    let l = kdfKeySize
+                    return ("kdfkey", l)
                 -- NK_DH 
                 NK_Enc -> do
                     l <- useAeadKeySize

--- a/src/Extraction/ExtractionBase.hs
+++ b/src/Extraction/ExtractionBase.hs
@@ -82,6 +82,7 @@ data Env = Env {
     _hmacMode :: HMACMode,
     _owlUserFuncs :: [(String, TB.UserFunc)],
     _funcs :: M.Map String ([(RustTy, String)] -> ExtractionMonad (RustTy, String)), -- return type, how to print
+    _specFuncs :: M.Map String ([OwlDoc] -> OwlDoc),
     _adtFuncs :: M.Map String (String, RustTy, Bool, [(RustTy, String)] -> ExtractionMonad  String),
     _specAdtFuncs :: M.Map String ([OwlDoc] -> OwlDoc),
     _typeLayouts :: M.Map String Layout,
@@ -439,7 +440,7 @@ initFuncs =
         ] 
 
 initEnv :: Flags -> String -> TB.Map String TB.UserFunc -> Env
-initEnv flags path userFuncs = Env flags path defaultCipher defaultHMACMode userFuncs initFuncs M.empty M.empty initTypeLayouts initLenConsts M.empty M.empty M.empty S.empty 0 Nothing [] [] M.empty
+initEnv flags path userFuncs = Env flags path defaultCipher defaultHMACMode userFuncs initFuncs M.empty M.empty M.empty initTypeLayouts initLenConsts M.empty M.empty M.empty S.empty 0 Nothing [] [] M.empty
 
 lookupTyLayout' :: String -> ExtractionMonad (Maybe Layout)
 lookupTyLayout' n = do

--- a/src/Extraction/SpecExtraction.hs
+++ b/src/Extraction/SpecExtraction.hs
@@ -186,6 +186,7 @@ specLenConsts = M.fromList [
         ("enckey", "KEY_SIZE()"),
         ("nonce", "NONCE_SIZE()"),
         ("mackey", "MACKEY_SIZE()"),
+        ("kdfkey", "KDFKEY_SIZE()"),
         -- ("maclen", hmacLen),
         -- ("pkekey", pkeKeySize),
         -- ("sigkey", sigKeySize),

--- a/tests/success/dhke.owl
+++ b/tests/success/dhke.owl
@@ -76,14 +76,14 @@ def bob_main () @ bob
        let k = kdf<;odh L[0];enckey;0>(0x, ss, 0x) in 
        corr_case nameOf(k) in 
        input ii, _ in 
-       case adec(k, ii) as Option (Name(d)) {
+       case adec(k, ii) /* as Option (Name(d)) */ {
        | None => ()
        | Some dd => 
          let ddd : if (sec(X) /\ sec(Y) /\ sec(KDF<enckey;0; enckey
          Name(d)>(0x, ss, 0x))) then
             Name(d) else Data<adv> = dd in
          ()
-       otherwise => ()
+       // otherwise => ()
        }
      | None => ()
     }

--- a/tests/success/kdf-enc.owl
+++ b/tests/success/kdf-enc.owl
@@ -9,6 +9,11 @@ name alice1 : nonce @ alice
 name alice2 : nonce @ alice
 name alice3 : nonce @ alice
 
+// hack so vest doesn't complain
+struct s {
+    _a : Data<adv> ||nonce||,
+    _b : Data<adv> ||nonce||
+}
 
 name k : kdf {ikm info.
     (info == 0x01) -> enckey Name(alice1) 
@@ -28,12 +33,14 @@ def alice_main() @ alice : Unit =
     let ek = kdf<0;;enckey;0>(get(k), 0x, 0x01) in 
     // assert (corr(k) ==> corr(KDF<k;0>(0x, 0x01)[0]));
     let c = aenc(ek, get(alice1)) in 
-    output c;
+    output c to endpoint(bob);
     let k2 = kdf<1;;kdfkey;0>(get(k), 0x, 0x02) in
     let ek2 = kdf<0;;enckey;0>(k2, 0x, 0x01) in
     let c2 = aenc(ek2, get(alice2)) in 
-    output c2;
+    output c2 to endpoint(bob);
     ()
+
+def bob_main() @ bob : Unit = ()
 
 /*
 def bob_main() @ bob : Unit = 

--- a/tests/success/kdf-enc.owl
+++ b/tests/success/kdf-enc.owl
@@ -28,6 +28,13 @@ name k : kdf {ikm info.
 corr [k] ==> [alice1]
 corr [k] ==> [alice2]
 
+// This is just a hack for extraction to test slicing the KDF output
+// It's not supposed to mean anything cryptographically
+name kk : kdf {ikm info.
+    True -> strict nonce || nonce
+} @ bob
+corr adv ==> [kk]
+
 def alice_main() @ alice : Unit = 
     corr_case k in
     let ek = kdf<0;;enckey;0>(get(k), 0x, 0x01) in 
@@ -40,7 +47,10 @@ def alice_main() @ alice : Unit =
     output c2 to endpoint(bob);
     ()
 
-def bob_main() @ bob : Unit = ()
+def bob_main() @ bob : Unit = 
+    let k1 = kdf<0;; nonce || nonce; 0>(get(kk), 0x, 0x) in 
+    let k2 = kdf<0;; nonce || nonce; 1>(get(kk), 0x, 0x) in 
+    ()
 
 /*
 def bob_main() @ bob : Unit = 

--- a/tests/success/ssh.owl
+++ b/tests/success/ssh.owl
@@ -64,22 +64,22 @@ odh l2:
         (info == 0x02) -> enckey Data<adv>
     }
 
-struct PFA_msg {
+struct pfa_msg {
     _pfa1: dhpk(a),
     _pfa2: Data<adv> ||signature||
 }
 
-struct PDIS_msg1 {
+struct pdis_msg1 {
     _pdis1_1: dhpk(b),
     _pdis2_1: Data<adv> ||signature||
 }
 // can just use an enum in the above struct instead of two structs
-struct PDIS_msg2 {
+struct pdis_msg2 {
     _pdis1_2: dhpk(b1),
     _pdis2_2: Data<adv> ||signature|| 
 }
 
-struct SDIS_msg {
+struct sdis_msg {
     _sdis1: dhpk(c),
     _sdis2: Data<adv> ||signature||
 }
@@ -120,12 +120,12 @@ def PDIS_actual(gb : Ghost,
     pcase (sec(a) /\ sec(b)) in 
     let g_pow_b1 = dhpk(get(b1)) in
     let signed_g_pow_b1 = sign(get(skPDIS), _comm_with_sdis(g_pow_b1)) in
-    let _ = output PDIS_msg2(g_pow_b1, signed_g_pow_b1) to endpoint(SDIS) in
+    let _ = output pdis_msg2(g_pow_b1, signed_g_pow_b1) to endpoint(SDIS) in
     
     input inp in
     let vkSDIS = get_vk(skSDIS) in
     corr_case skSDIS in
-    parse inp as SDIS_msg(sdis1, sdis2) in 
+    parse inp as sdis_msg(sdis1, sdis2) in 
     case vrfy(vkSDIS, sdis1, sdis2) {
         | None => ()
         | Some g_pow_c =>
@@ -137,7 +137,7 @@ def PDIS_actual(gb : Ghost,
                 let k = kdf<; odh l2[0]; enckey; 0>(0x, ss, 0x02) in
                 
                 // request PFA to sign
-                let request = _req(1) in // TODO: 1 is the hash
+                let request = _req(0x01) in // TODO: 0x01 is the hash
                 pcase (corr(skPFA) /\ gb != dh_combine(dhpk(get(a)), get(b))) in
                 pcase (corr(a) \/ corr(b)) in
                 let enc_request = aenc(k11, request) in
@@ -169,12 +169,12 @@ def SDIS_actual () @ SDIS
 : Unit =
     let g_pow_c = dhpk(get(c)) in
     let signed_g_pow_c = sign(get(skSDIS), g_pow_c) in
-    let _ = output SDIS_msg(g_pow_c, signed_g_pow_c) to endpoint(PDIS) in
+    let _ = output sdis_msg(g_pow_c, signed_g_pow_c) to endpoint(PDIS) in
 
     input inp in
     let vkPDIS = get_vk(skPDIS) in
     corr_case skPDIS in
-    parse inp as PDIS_msg2(pdis1_2, pdis2_2) in 
+    parse inp as pdis_msg2(pdis1_2, pdis2_2) in 
     case vrfy(vkPDIS, pdis1_2, pdis2_2) {
         | None => ()
         | Some m =>
@@ -191,12 +191,12 @@ def SDIS_actual () @ SDIS
                         
                         input inp2 in
                         corr_case nameOf(k) in 
-                        case adec(k, inp2) as Option (Data<adv>)  {
+                        case adec(k, inp2) /* as Option (Data<adv>) */ {
                             | None => ()
                             | Some m'' =>
                                 // m'' is the signature which was forwarded using the agent from the client
                                 ()
-                            otherwise => ()
+                            /* otherwise => () */
                         }
                     }
                 otherwise => ()
@@ -209,12 +209,12 @@ def PFA_KE () @ PFA
 : Unit =
     let g_pow_a = dhpk(get(a)) in
     let signed_g_pow_a = sign(get(skPFA), _signed_by_PFA_g_pow_a(g_pow_a)) in
-    let _ = output PFA_msg(g_pow_a, signed_g_pow_a) to endpoint(PDIS) in
+    let _ = output pfa_msg(g_pow_a, signed_g_pow_a) to endpoint(PDIS) in
 
     input inp in // signed g_pow_b
     let vkPDIS = get_vk(skPDIS) in
     corr_case skPDIS in
-    parse inp as PDIS_msg1(pdis1_1, pdis2_1) in      
+    parse inp as pdis_msg1(pdis1_1, pdis2_1) in      
     case vrfy(vkPDIS, pdis1_1, pdis2_1) {
         | None => ()
         | Some m =>
@@ -241,12 +241,12 @@ def PDIS_KE () @ PDIS
 : Unit =
     let g_pow_b = dhpk(get(b)) in
     let signed_g_pow_b = sign(get(skPDIS), _comm_with_pfa(g_pow_b)) in
-    let _ = output PDIS_msg1(g_pow_b, signed_g_pow_b) to endpoint(PFA) in
+    let _ = output pdis_msg1(g_pow_b, signed_g_pow_b) to endpoint(PFA) in
 
     input inp in // from PFA (KE), signed g_pow_a
     let vkPFA = get_vk(skPFA) in
     corr_case skPFA in
-    parse inp as PFA_msg(pfa1, pfa2) in 
+    parse inp as pfa_msg(pfa1, pfa2) in 
     case vrfy(vkPFA, pfa1, pfa2) {
         | None => ()
         | Some m =>
@@ -259,7 +259,7 @@ def PDIS_KE () @ PDIS
                         let ss   = dh_combine(g_pow_a, get(b)) in
                         pcase (ss == dh_combine(dhpk(get(a)), get(b))) in
                         let k11 = kdf<; odh l1[0]; enckey; 0>(0x, ss, 0x01) in
-                        let _ = output 0 to endpoint(SDIS) in // TODO: The hash stuff
+                        let _ = output 0x to endpoint(SDIS) in // TODO: The hash stuff
                         call PDIS_actual(ss, k11)
                     }
                 otherwise => ()


### PR DESCRIPTION
Tested on `ssh.owl`, `dhke.owl`, and `kdf-enc.owl`. Also includes improved ghost stuff. I believe all of the handling of the new KDFs should work now.

I haven't tested on wireguard yet because I don't know what the status of that is. Presumably we will need to make a bunch more extraction changes based on wireguard, so I will hold off.