### PR TITLE
fix: `$LOCALITY_main()` functions; output to endpoints

### DIFF
--- a/docs/encrypted_key_basic.owl
+++ b/docs/encrypted_key_basic.owl
@@ -20,10 +20,10 @@ enum Result {
     | NoResult
 }
 
-def alice () @ alice
+def alice_main () @ alice
      : if sec(k_data) then Result else Data<adv> = 
     let c = aenc(get(psk), get(k_data)) in
-    output c;
+    output c to endpoint(bob);
     input i in 
     corr_case k_data in
     let res = adec(get(k_data), i) in 
@@ -32,13 +32,13 @@ def alice () @ alice
      | None => NoResult()
     }
     
-def bob () @ bob : Unit =
+def bob_main () @ bob : Unit =
     input i in // i : Data<adv>
     corr_case psk in
     case adec(get(psk), i)  {
      | Some k => 
         let c = aenc(k, get(x)) in
-        output c
+        output c to endpoint(alice)
      | None => ()
     }
         


### PR DESCRIPTION
As of 7a6de5d6e1f2736a5e5f9b4a55a72c6085126d3c, I still get:

```sh-session
user@dev:~/owl$ cabal run owl -- -e docs/encrypted_key_basic.owl
Up to date
Found smtcache file: docs/encrypted_key_basic.owl.smtcache
Typechecking success!
Extraction error: Locality Top_alice does not have a defined main function. For extraction, there should be a defined entry point function that must not take arguments: def Top_alice_main () @ Top_alice
```

With this patch from #18, I get the expected:

```sh-session
user@dev:~/owl$ cabal run owl -- -e docs/encrypted_key_basic.owl
Up to date
Found smtcache file: docs/encrypted_key_basic.owl.smtcache
Typechecking success!
Successfully extracted to file extraction/src/main.rs
```