### PR TITLE
Use updated Vest

### DIFF
--- a/extraction/Cargo.toml
+++ b/extraction/Cargo.toml
@@ -32,6 +32,7 @@ x25519-dalek = { version = "2.0.0", features = ["static_secrets"] }
 builtin = { git = "https://github.com/verus-lang/verus", branch = "main" }
 builtin_macros = { git = "https://github.com/verus-lang/verus", branch = "main" }
 vstd = { git = "https://github.com/verus-lang/verus", branch = "main" }
+# vest = { git = "https://github.com/secure-foundations/vest", branch = "main" }
 # parsley = { git = "https://github.com/secure-foundations/parsley", branch = "main" }
 
 [features]

--- a/extraction/preamble.rs
+++ b/extraction/preamble.rs
@@ -126,7 +126,7 @@ pub fn owl_sample<A>(Tracked(t): Tracked<&mut ITreeToken<A,Endpoint>>, n: usize)
 
 
 // #[verifier(external_body)]
-// pub fn owl_output_serialize_fused<'a, A, C: View + Combinator>(
+// pub fn owl_output_serialize_fused<'a, A, C: View + Combinator + SpecCombinator>(
 //     Tracked(t): Tracked<&mut ITreeToken<A, Endpoint>>,
 //     comb: C,
 //     val: C::Result<'a>,
@@ -144,7 +144,7 @@ pub fn owl_sample<A>(Tracked(t): Tracked<&mut ITreeToken<A,Endpoint>>, n: usize)
 //     let ser_result = comb.serialize(val, obuf, 0);
 //     assume(ser_result.is_ok());
 //     if let Ok((num_written)) = ser_result {
-//         vec_truncate(obuf, num_written);
+//         // assert(obuf.view() == comb.spec_serialize((arg.view()))->Ok_0);
 //     } else {
 //         assert(false);
 //     }

--- a/extraction/preamble.rs
+++ b/extraction/preamble.rs
@@ -4,7 +4,7 @@
 #![allow(unused_imports)]
 #![allow(unused_variables)]
 
-pub use vstd::{modes::*, prelude::*, seq::*, string::*};
+pub use vstd::{modes::*, prelude::*, seq::*, view::*};
 pub mod speclib;
 pub use crate::speclib::{*, itree::*};
 pub mod execlib;
@@ -15,13 +15,14 @@ pub mod owl_hkdf;
 pub mod owl_hmac;
 pub mod owl_pke;
 pub mod owl_util;
-pub use parsley::{
+pub use vest::{
     *,
     properties::*,
     regular::*,
     regular::builder::*,
     regular::bytes::*,
-    regular::bytes_const::*,
+    // regular::bytes_const::*,
+    regular::tag::*,
     regular::choice::*,
     regular::tail::*,
     regular::uints::*,
@@ -124,30 +125,30 @@ pub fn owl_sample<A>(Tracked(t): Tracked<&mut ITreeToken<A,Endpoint>>, n: usize)
 }
 
 
-#[verifier(external_body)]
-pub fn owl_output_serialize_fused<'a, A, C: Combinator<'a> + 'a>(
-    Tracked(t): Tracked<&mut ITreeToken<A, Endpoint>>,
-    comb: C,
-    val: C::Result,
-    obuf: &mut Vec<u8>,
-    dest_addr: &str,
-    ret_addr: &str,
-)
-    requires
-        comb.spec_serialize(val.view()) matches Ok(b) ==> 
-            old(t).view().is_output(b, endpoint_of_addr(dest_addr.view())),
-    ensures
-        t.view() == old(t).view().give_output(),
-        comb.spec_serialize(val.view()) matches Ok(b) ==> obuf.view() == b,
-{
-    let ser_result = comb.serialize(val, obuf, 0);
-    assume(ser_result.is_ok());
-    if let Ok((num_written)) = ser_result {
-        vec_truncate(obuf, num_written);
-    } else {
-        assert(false);
-    }
-}
+// #[verifier(external_body)]
+// pub fn owl_output_serialize_fused<'a, A, C: View + Combinator>(
+//     Tracked(t): Tracked<&mut ITreeToken<A, Endpoint>>,
+//     comb: C,
+//     val: C::Result<'a>,
+//     obuf: &mut Vec<u8>,
+//     dest_addr: &str,
+//     ret_addr: &str,
+// ) where <C as vstd::view::View>::V: vest::properties::SecureSpecCombinator<SpecResult = <C::Owned as vstd::view::View>::V>
+//     requires
+//         comb.spec_serialize(val.view()) matches Ok(b) ==> 
+//             old(t).view().is_output(b, endpoint_of_addr(dest_addr.view())),
+//     ensures
+//         t.view() == old(t).view().give_output(),
+//         comb.spec_serialize(val.view()) matches Ok(b) ==> obuf.view() == b,
+// {
+//     let ser_result = comb.serialize(val, obuf, 0);
+//     assume(ser_result.is_ok());
+//     if let Ok((num_written)) = ser_result {
+//         vec_truncate(obuf, num_written);
+//     } else {
+//         assert(false);
+//     }
+// }
 
 
 // for debugging purposes, not used by the compiler

--- a/extraction/preamble.rs
+++ b/extraction/preamble.rs
@@ -124,30 +124,30 @@ pub fn owl_sample<A>(Tracked(t): Tracked<&mut ITreeToken<A,Endpoint>>, n: usize)
 }
 
 
-// #[verifier(external_body)]
-// pub fn owl_output_serialize_fused<'a, A, C: View + Combinator + SpecCombinator>(
-//     Tracked(t): Tracked<&mut ITreeToken<A, Endpoint>>,
-//     comb: C,
-//     val: C::Result<'a>,
-//     obuf: &mut Vec<u8>,
-//     dest_addr: &str,
-//     ret_addr: &str,
-// ) where <C as vstd::view::View>::V: vest::properties::SecureSpecCombinator<SpecResult = <C::Owned as vstd::view::View>::V>
-//     requires
-//         comb.spec_serialize(val.view()) matches Ok(b) ==> 
-//             old(t).view().is_output(b, endpoint_of_addr(dest_addr.view())),
-//     ensures
-//         t.view() == old(t).view().give_output(),
-//         comb.spec_serialize(val.view()) matches Ok(b) ==> obuf.view() == b,
-// {
-//     let ser_result = comb.serialize(val, obuf, 0);
-//     assume(ser_result.is_ok());
-//     if let Ok((num_written)) = ser_result {
-//         // assert(obuf.view() == comb.spec_serialize((arg.view()))->Ok_0);
-//     } else {
-//         assert(false);
-//     }
-// }
+#[verifier(external_body)]
+pub fn owl_output_serialize_fused<'a, A, C: View + Combinator>(
+    Tracked(t): Tracked<&mut ITreeToken<A, Endpoint>>,
+    comb: C,
+    val: C::Result<'a>,
+    obuf: &mut Vec<u8>,
+    dest_addr: &str,
+    ret_addr: &str,
+) where <C as View>::V: SecureSpecCombinator<SpecResult = <C::Result<'a> as View>::V>
+    requires
+        comb@.spec_serialize(val.view()) matches Ok(b) ==> 
+            old(t).view().is_output(b, endpoint_of_addr(dest_addr.view())),
+    ensures
+        t.view() == old(t).view().give_output(),
+        comb@.spec_serialize(val.view()) matches Ok(b) ==> obuf.view() == b,
+{
+    let ser_result = comb.serialize(val, obuf, 0);
+    assume(ser_result.is_ok());
+    if let Ok((num_written)) = ser_result {
+        // assert(obuf.view() == comb.spec_serialize((arg.view()))->Ok_0);
+    } else {
+        assert(false);
+    }
+}
 
 
 // for debugging purposes, not used by the compiler

--- a/extraction/preamble.rs
+++ b/extraction/preamble.rs
@@ -16,12 +16,11 @@ pub mod owl_hmac;
 pub mod owl_pke;
 pub mod owl_util;
 pub use vest::{
-    *,
     properties::*,
     regular::*,
     regular::builder::*,
     regular::bytes::*,
-    // regular::bytes_const::*,
+    regular::bytes_n::*,
     regular::tag::*,
     regular::choice::*,
     regular::tail::*,

--- a/extraction/run_verus.sh
+++ b/extraction/run_verus.sh
@@ -36,7 +36,6 @@ fi
 src_path=$ext_dir_path/src
 
 main_file=$src_path/main.rs
-vest_file=$src_path/parse_serialize.vest
 
 if [ $format = "true" ]; then
     echo ""

--- a/extraction/run_verus.sh
+++ b/extraction/run_verus.sh
@@ -5,8 +5,8 @@ set -euo pipefail
 function usage() {
     echo "Usage: ${0} [-n] <path-to-extraction-dir>"
     echo "You must have verus and verusfmt in your path,"
-    echo "and the PARSLEYPATH environment variable set to the path"
-    echo "to the crate root of the parsley repo."
+    echo "and the VESTPATH environment variable set to the path"
+    echo "to the crate root of the vest crate in the vest repo."
     exit 2
 }
 
@@ -46,7 +46,7 @@ fi
 
 echo ""
 echo "VERIFYING, COMPILING, AND EXPORTING PARSLEY" 
-pushd $PARSLEYPATH
+pushd $VESTPATH
 make
 popd
 
@@ -58,8 +58,8 @@ popd
 
 echo ""
 echo "VERIFYING" 
-verus -L dependency=$(realpath $ext_dir_path/target/debug/deps) $( find $ext_dir_path/target/debug/deps -name \*.rlib -exec realpath '{}' ';' | awk -F/ '{print "--extern " substr ($NF,4,index($NF,"-") - 4) "=" $0}' | grep -v vstd | grep -v builtin ) --extern parsley=$PARSLEYPATH/libparsley.rlib --import parsley=$PARSLEYPATH/parsley.verusdata --multiple-errors=100 --rlimit=100 $main_file $verus_args -V spinoff-all 
-
+verus -L dependency=$(realpath $ext_dir_path/target/debug/deps) $( find $ext_dir_path/target/debug/deps -name \*.rlib -exec realpath '{}' ';' | awk -F/ '{print "--extern " substr ($NF,4,index($NF,"-") - 4) "=" $0}' | grep -v vstd | grep -v builtin ) --extern vest=$VESTPATH/libvest.rlib --import vest=$VESTPATH/vest.verusdata --multiple-errors=100 --rlimit=100 $main_file $verus_args -V spinoff-all 
+# verus -L dependency=$(realpath $ext_dir_path/target/debug/deps) $( find $ext_dir_path/target/debug/deps -name \*.rlib -exec realpath '{}' ';' | awk -F/ '{print "--extern " substr ($NF,4,index($NF,"-") - 4) "=" $0}' | grep -v vstd | grep -v builtin ) --import vest=$VESTPATH/vest.verusdata --multiple-errors=100 --rlimit=100 $main_file $verus_args -V spinoff-all 
 
 
 if [ -z $verus_args ]; then

--- a/extraction/src/execlib.rs
+++ b/extraction/src/execlib.rs
@@ -1,7 +1,7 @@
 use std::rc::Rc;
-pub use vstd::{modes::*, prelude::*, seq::*, string::*, slice::*};
+pub use vstd::{modes::*, prelude::*, seq::*, view::*, slice::*};
 use crate::{speclib, *};
-use parsley::regular::builder::*;
+use vest::regular::builder::*;
 
 verus! {
 

--- a/extraction/src/execlib.rs
+++ b/extraction/src/execlib.rs
@@ -1,6 +1,6 @@
 use std::rc::Rc;
 pub use vstd::{modes::*, prelude::*, seq::*, view::*, slice::*};
-use crate::{speclib, *};
+use crate::{*, speclib::*};
 use vest::regular::builder::*;
 
 verus! {

--- a/extraction/src/execlib.rs
+++ b/extraction/src/execlib.rs
@@ -231,7 +231,6 @@ pub exec fn owl_concat(a: &[u8], b: &[u8]) -> (res: Vec<u8>)
     v
 }
 
-
 #[verifier(external_body)]
 pub exec fn vec_u8_from_elem(e: u8, n: usize) -> (res: Vec<u8>)
     ensures res.view() == Seq::new(n as nat, |i| e)

--- a/src/Extraction/ConcreteAST.hs
+++ b/src/Extraction/ConcreteAST.hs
@@ -204,7 +204,7 @@ instance (OwlPretty v, OwlPretty t) => OwlPretty (Typed v t) where
     owlpretty (Typed v t) = if flagShouldPrettyTypes then parens (owlpretty t) <+> owlpretty ":" <+> owlpretty v else owlpretty t
 
 instance OwlPretty ParsleyCombinator where
-    owlpretty (PCConstBytes n s) = owlpretty "ConstBytes" <> brackets (owlpretty n) <> parens (owlpretty s)
+    owlpretty (PCConstBytes n s) = owlpretty "Tag<BytesN" <> angles (owlpretty n) <> owlpretty ", [u8; " <> owlpretty n <> owlpretty "]" <> parens (owlpretty s)
     owlpretty (PCBytes l) = owlpretty "Bytes" <> parens (owlpretty l)
     owlpretty PCTail = owlpretty "Tail"
     owlpretty PCBuilder = owlpretty "BuilderCombinator"

--- a/src/Extraction/ExtractionBase.hs
+++ b/src/Extraction/ExtractionBase.hs
@@ -395,7 +395,7 @@ specCombTyOf' (FEnum _ cs) = do
     cs' <- mapM (withJustNothing specCombTyOf' . snd) cs
     case sequence cs' of
         Just cs'' -> do
-            let consts = [[di|SpecConstInt<u8, U8<#{i}>>|] | i <- [1 .. length cs'']]
+            let consts = [[di|Tag<U8, u8>|] | i <- [1 .. length cs'']]
             let cs''' = map (fromMaybe [di|Bytes|]) cs''
             let constCs = zipWith (\c i -> [di|(#{c}, #{i})|]) consts cs''' 
             let nest = nestOrdChoiceTy constCs
@@ -421,7 +421,7 @@ execCombTyOf' (FEnum _ cs) = do
     cs' <- mapM (withJustNothing execCombTyOf' . snd) cs
     case sequence cs' of
         Just cs'' -> do
-            let consts = [[di|ConstInt<u8, U8<#{i}>>|] | i <- [1 .. length cs'']]
+            let consts = [[di|Tag<U8, u8>|] | i <- [1 .. length cs'']]
             let cs''' = map (fromMaybe [di|Bytes|]) cs''
             let constCs = zipWith (\c i -> [di|(#{c}, #{i})|]) consts cs''' 
             let nest = nestOrdChoiceTy constCs
@@ -460,7 +460,7 @@ specCombOf' constSuffix (FEnum _ cs) = do
                             Just (c, const) -> Just c : cs
                             Nothing -> Nothing : cs
                     ) [] ccs''
-            let consts = [[di|SpecConstInt::new(U8::<#{i}>)|] | i <- [1 .. length cs'']]
+            let consts = [[di|Tag::spec_new(U8, #{i})|] | i <- [1 .. length cs'']]
             let cs''' = map (fromMaybe [di|Bytes(0)|]) cs''
             let constCs = zipWith (\c i -> [di|(#{c}, #{i})|]) consts cs'''
             let nest = nestOrdChoice constCs
@@ -501,7 +501,7 @@ execCombOf' constSuffix (FEnum _ cs) = do
                             Just (c, const) -> Just c : cs
                             Nothing -> Nothing : cs
                     ) [] ccs''
-            let consts = [[di|ConstInt::new(U8::<#{i}>)|] | i <- [1 .. length cs'']]
+            let consts = [[di|Tag::new(U8, #{i})|] | i <- [1 .. length cs'']]
             let cs''' = map (fromMaybe [di|Bytes(0)|]) cs''
             let constCs = zipWith (\c i -> [di|(#{c}, #{i})|]) consts cs''' 
             let nest = nestOrdChoice constCs

--- a/src/Extraction/GenVerus.hs
+++ b/src/Extraction/GenVerus.hs
@@ -421,7 +421,6 @@ genVerusCAExpr ae = do
                     let exec_comb = #{execcomb};
                     let ser_result = exec_comb.serialize(#{execargs}, &mut ser_buf, 0);
                     if let Ok((num_written)) = ser_result {
-                        vec_truncate(&mut ser_buf, num_written);
                         ser_buf
                     } else {
                         // TODO better error name
@@ -1070,7 +1069,7 @@ genVerusStruct (CStruct name fieldsFV isVest) = do
                     let mut obuf = vec_u8_of_len(#{(hsep . punctuate (pretty "+")) lens});
                     let ser_result = exec_comb.serialize(#{fieldsAsSlices}, &mut obuf, 0);
                     if let Ok((num_written)) = ser_result {
-                        vec_truncate(&mut obuf, num_written);
+                        assert(obuf.view() == #{specSerInner}(arg.view())->Some_0);
                         Some(obuf)
                     } else {
                         None
@@ -1339,7 +1338,7 @@ genVerusEnum (CEnum name casesFV isVest execComb) = do
                             let mut obuf = vec_u8_of_len(1 + #{lhsXLen});
                             let ser_result = exec_comb.serialize(#{rhs}, &mut obuf, 0);
                             if let Ok((num_written)) = ser_result {
-                                vec_truncate(&mut obuf, num_written);
+                                assert(obuf.view() == #{specSerInner}(arg.view())->Some_0);
                                 Some(obuf)
                             } else {
                                 None

--- a/src/Extraction/GenVerus.hs
+++ b/src/Extraction/GenVerus.hs
@@ -1268,7 +1268,7 @@ genVerusEnum (CEnum name casesFV isVest execComb) = do
                     let (lhsX, rhsX) = case topt of
                             Just _ -> ([di|(_,x)|], [di|x|])
                             Nothing -> ([di|_|], [di||])
-                    lhs <- listIdxToEitherPat i l lhsX
+                    lhs <- listIdxToInjPat i l lhsX
                     rhs <- case topt of
                             Just (RTOwlBuf l) -> (rhsX, u8slice) `cast` RTOwlBuf l
                             _ -> return rhsX
@@ -1280,7 +1280,7 @@ genVerusEnum (CEnum name casesFV isVest execComb) = do
                     let (lhsX, rhsX) = case topt of
                             Just _ -> ([di|(_,x)|], [di|x|])
                             Nothing -> ([di|_|], [di||])
-                    lhs <- listIdxToEitherPat i l lhsX
+                    lhs <- listIdxToInjPat i l lhsX
                     rhs <- case topt of
                             Just (RTOwlBuf l) -> ([di|slice_to_vec(#{rhsX})|], vecU8) `cast` RTOwlBuf l
                             _ -> return rhsX
@@ -1331,7 +1331,7 @@ genVerusEnum (CEnum name casesFV isVest execComb) = do
                     let (lhsX, lhsXLen,  rhsX) = case topt of
                             Just _ -> ([di|x|], [di|x.len()|], [di|((), x.as_slice())|])
                             Nothing -> ([di||], [di|0|], [di|((), &empty_vec.as_slice())|])
-                    rhs <- listIdxToEitherPat i l rhsX
+                    rhs <- listIdxToInjResult i l rhsX
                     return [__di|
                     #{verusName}::#{caseName}(#{lhsX}) => {                
                         if no_usize_overflows![ 1, #{lhsXLen} ] {


### PR DESCRIPTION
This PR adds support for the updated [Vest library](https://github.com/secure-foundations/vest) of verified parser combinators, replacing prior use of an old, private version of the same library. 

Depends on https://github.com/secure-foundations/vest/pull/11 for the fused buffer optimizations, so probably shouldn't be merged until that PR is merged into Vest.