### PR TITLE
Recursive name and nametype definitions

### DIFF
--- a/prelude.smt2
+++ b/prelude.smt2
@@ -496,6 +496,7 @@
 
 (declare-sort Index)
 (declare-fun Happened (String (List Index) (List Bits)) Bool)
+(declare-fun IndexSucc (Index) Index)
 
 ;; Builtin function axioms
 (assert (distinct TRUE FALSE UNIT))

--- a/src/AST.hs
+++ b/src/AST.hs
@@ -96,6 +96,7 @@ instance Show ResolvedPath where
 
 
 data Idx = IVar (Ignore Position) (Ignore String) IdxVar
+         | ISucc (Ignore Position) Idx
     deriving (Show, Generic, Typeable)
 
 

--- a/src/AST.hs
+++ b/src/AST.hs
@@ -97,6 +97,7 @@ instance Show ResolvedPath where
 
 data Idx = IVar (Ignore Position) (Ignore String) IdxVar
          | ISucc (Ignore Position) Idx
+         | IZero (Ignore Position)
     deriving (Show, Generic, Typeable)
 
 
@@ -507,6 +508,7 @@ instance Alpha Idx
 instance Alpha Endpoint
 instance Subst Idx Idx where
     isvar (IVar _ _ v) = Just (SubstName v)
+    isvar _ = Nothing
 instance Subst AExpr Idx
 instance Subst ResolvedPath Idx
 

--- a/src/Parse.hs
+++ b/src/Parse.hs
@@ -1772,6 +1772,11 @@ parseIdxExp =
         symbol ")"
         p' <- getPosition
         return $ ISucc (ignore $ mkPos p p') i
+    ) <|> (do
+        p <- getPosition
+        reserved "0"
+        p' <- getPosition
+        return $ IZero (ignore $ mkPos p p')
     )
 
 

--- a/src/Parse.hs
+++ b/src/Parse.hs
@@ -1738,7 +1738,7 @@ parseParam =
             (reserved "session" >> (return $ Just IdxSession))
             <|>
             (reserved "pid" >> (return $ Just IdxPId))
-        i <- parseIdx
+        i <- parseIdxExp
         return $ ParamIdx i ot)
     <|>
     (try $ do
@@ -1768,7 +1768,7 @@ parseIdxExp =
         p <- getPosition
         reserved "succ"
         symbol "("
-        i <- parseIdx
+        i <- parseIdxExp
         symbol ")"
         p' <- getPosition
         return $ ISucc (ignore $ mkPos p p') i
@@ -1808,7 +1808,7 @@ parseIdxParams1 = do
 parseIdxParamsNoAngles :: Parser ([Idx], [Idx])
 parseIdxParamsNoAngles = do
     inds <- optionMaybe $ do
-        is <- parseIdx `sepBy` symbol ","
+        is <- parseIdxExp `sepBy` symbol ","
         ps <- optionMaybe $ do
             symbol "@"
             parseIdx `sepBy` symbol ","

--- a/src/Pass/PathResolution.hs
+++ b/src/Pass/PathResolution.hs
@@ -162,20 +162,22 @@ resolveDecls (d:ds) =
       DeclName s ixs -> do
           (is, ndecl) <- unbind ixs
           p <- view curPath
-          local (over namePaths $ T.insert s p) $ do
-            ndecl' <- case ndecl of
-                        DeclAbstractName -> return DeclAbstractName
-                        DeclAbbrev bne2 -> do
-                            (xs, ne2) <- unbind bne2
-                            ne2' <- resolveNameExp ne2
-                            return $ DeclAbbrev $ bind xs ne2'
-                        DeclBaseName nt ls -> do
-                            nt' <- resolveNameType nt
-                            ls' <- mapM (resolveLocality (d^.spanOf)) ls
-                            return $ DeclBaseName nt' ls'
-            let d' = Spanned (d^.spanOf) $ DeclName s $ bind is ndecl'
-            ds' <- resolveDecls ds
-            return $ d' : ds'
+          -- TODO: adding both name and nameType paths for now
+          local (over namePaths $ T.insert s p) $
+            local (over nameTypePaths $ T.insert s p) $ do
+                ndecl' <- case ndecl of
+                            DeclAbstractName -> return DeclAbstractName
+                            DeclAbbrev bne2 -> do
+                                (xs, ne2) <- unbind bne2
+                                ne2' <- resolveNameExp ne2
+                                return $ DeclAbbrev $ bind xs ne2'
+                            DeclBaseName nt ls -> do
+                                nt' <- resolveNameType nt
+                                ls' <- mapM (resolveLocality (d^.spanOf)) ls
+                                return $ DeclBaseName nt' ls'
+                let d' = Spanned (d^.spanOf) $ DeclName s $ bind is ndecl'
+                ds' <- resolveDecls ds
+                return $ d' : ds'
       DeclDefHeader s isl -> do
           (is, l) <- unbind isl
           l' <- resolveLocality (d^.spanOf) l

--- a/src/Pretty.hs
+++ b/src/Pretty.hs
@@ -51,6 +51,8 @@ instance (OwlPretty a, OwlPretty b) => OwlPretty (a, b) where
 
 instance OwlPretty Idx where
     owlpretty (IVar _ s _) = pretty $ unignore s
+    owlpretty (ISucc _ i) = pretty "succ(" <> owlpretty i <> pretty ")"
+    owlpretty (IZero _) = pretty "0"
 
 owlprettyIdxParams :: ([Idx], [Idx]) -> Doc AnsiStyle
 owlprettyIdxParams  ([], []) = mempty

--- a/src/SMTBase.hs
+++ b/src/SMTBase.hs
@@ -635,6 +635,9 @@ symIndex idx@(IVar ispan iname v) = do
           indices <- view $ inScopeIndices
           liftIO $ putStrLn $ "Unknown index: " ++ show (unignore iname)
           liftCheck $ typeError (show $ owlpretty "SMT ERROR: unknown index " <> owlpretty iname <> owlpretty " under inScopeIndices " <> (list $ map (owlpretty . fst) indices) <> owlpretty " and iEnv " <> (list $ map (owlpretty . fst) $ M.toList iEnv))
+symIndex succ@(ISucc pos i) = do
+    iv <- symIndex i
+    return $ SApp [SAtom "IndexSucc", iv]
 
 data SMTNameDef = 
     SMTBaseName (SExp, ResolvedPath) (Bind ([IdxVar], [IdxVar]) (Maybe NameType))

--- a/src/Typing.hs
+++ b/src/Typing.hs
@@ -1396,15 +1396,7 @@ nameTypeUniform nt =
       NT_App p@(PRes (PDot _ n)) ps@(sess_ids, _) as -> do
         nt_def <- view curNameTypeDef
         case nt_def of
-            Just (n', _) | n == n' ->
-                -- Check that ps contains strictly increasing indices
-                if any (\i -> case i of
-                        ISucc _ _ -> True
-                        _ -> False) sess_ids then
-                    return ()
-                else
-                    typeError $ "Recursive name type application should have at least one strictly increasing index: "
-                        ++ show (owlpretty nt)
+            Just (n', _) | n == n' -> return ()
             _ -> resolveNameTypeApp p ps as >>= nameTypeUniform
       NT_MAC _ -> return ()
       NT_KDF _ _ -> return ()
@@ -1520,12 +1512,18 @@ checkNameType' rec_nt nt = withSpan (nt^.spanOf) $
         checkTy t
         checkNoTopTy False t
         checkTyPubLen t
-      NT_App p@(PRes (PDot _ n)) ps as -> do
+      NT_App p@(PRes (PDot _ n)) ps@(sess_ids, _) as -> do
           nt_def <- view curNameTypeDef
           case nt_def of
             Just (n', _) | n == n' ->
-              -- TODO: check that ps contains strictly increasing indices
-              return ()
+              -- Check that ps contains strictly increasing indices
+              if any (\i -> case i of
+                    ISucc _ _ -> True
+                    _ -> False) sess_ids then
+                return ()
+              else
+                typeError $ "Recursive name type application should have at least one strictly increasing index: "
+                    ++ show (owlpretty nt)
             _ -> case rec_nt of
                 Just n' | n == n' -> return ()
                 _ -> resolveNameTypeApp p ps as >>= checkNameType' (Just n)

--- a/src/Typing.hs
+++ b/src/Typing.hs
@@ -67,7 +67,7 @@ emptyEnv f = do
     m <- newIORef $ M.empty
     rs <- newIORef []
     memo <- mkMemoEntry 
-    return $ Env mempty Nothing mempty mempty Nothing f initDetFuncs (TcGhost False) mempty [(Nothing, emptyModBody ModConcrete)] mempty 
+    return $ Env mempty Nothing Nothing mempty mempty Nothing f initDetFuncs (TcGhost False) mempty [(Nothing, emptyModBody ModConcrete)] mempty 
         interpUserFunc r m [memo] mempty rs r' r'' (typeError') checkNameType normalizeTy normalizeProp decideProp Nothing [] False False def
 
 
@@ -815,48 +815,62 @@ allM (x:xs) f = do
 
 subNameType :: NameType -> NameType -> Check Bool
 subNameType nt1 nt2 = do
-    res <- withPushLog $ case (nt1^.val, nt2^.val) of
-             _ | nt1 `aeq` nt2 -> return True
-             (NT_DH, NT_DH) -> return True
-             (NT_Sig t1, NT_Sig t2) -> isSubtype t1 t2
-             (NT_Nonce s1, NT_Nonce s2) -> return $ s1 == s2
-             (NT_Enc t1, NT_Enc t2) -> isSubtype t1 t2
-             (NT_StAEAD t1 xp1 pth1 xpat1, NT_StAEAD t2 xp2 pth2 xpat2) -> do
-                 b1 <- isSubtype t1 t2
-                 ((x, slf), p1) <- unbind xp1
-                 ((x', slf'), p2_) <- unbind xp2
-                 let p2 = subst x' (aeVar' x) $ subst slf' (aeVar' slf) $ p2_
-                 b2 <- withVars [(x, (ignore $ show x, Nothing, tGhost)), (slf, (ignore $ show slf, Nothing, tGhost))] $ decideProp $ p1 `pImpl` p2
-                 b3 <- return $ pth1 `aeq` pth2
-                 (z, pat1) <- unbind xpat1
-                 (w, pat2) <- unbind xpat2
-                 b4 <- withVars [(z, (ignore $ show z, Nothing, tGhost))] $ decideProp $ pat1 `pEq` (subst w (aeVar' z) pat2)
-                 return $ b1 && (b2 == Just True) && b3 && (b4 == Just True)
-             (NT_KDF pos1 body1, NT_KDF pos2 body2) -> do
-                 (((sx, x), (sy, y), (sz, z)), bnds) <- unbind body1
-                 (((sx', x'), (sy', y'), (sz', z')), bnds') <- unbind body2
-                 withVars [(x, (ignore sx, Nothing, tGhost)), (y, (ignore sy, Nothing, tGhost)), (z, (ignore sz, Nothing, tGhost))] $ 
-                     if pos1 == pos2 && length bnds == length bnds' then go bnds (substs [(x', aeVar' x), (y', aeVar' y), (z', aeVar' z)] bnds') else return False
-                     where
-                         go :: [Bind [IdxVar] (Prop, [(KDFStrictness, NameType)])] -> 
-                               [Bind [IdxVar] (Prop, [(KDFStrictness, NameType)])] -> 
-                               Check Bool
-                         go [] [] = return True
-                         go (b1:xs) (b2:ys) = do
-                             (is1, rest1) <- unbind b1
-                             (is2, rest2_) <- unbind b2
-                             bhere <- if length is1 == length is2 then do
-                                 let rest2 = substs (map (\(i1, i2) -> (i2, mkIVar i1)) (zip is1 is2)) rest2_
-                                 withIndices (map (\i -> (i, (ignore $ show i, IdxGhost))) is1) $ do
-                                     b1 <- decideProp $ pImpl (fst rest1) (fst rest2)
-                                     if (b1 == Just True) then do 
-                                         allM (zip (snd rest1) (snd rest2)) $ \(nt1, nt2) -> 
-                                             if (fst nt1 == fst nt2) then subNameType (snd nt1) (snd nt2) else return False
-                                     else return False
-                                 else return False
-                             if bhere then go xs ys else return False
-             _ -> return False                                
-    return res
+    -- Some special handling of recursive name types
+    case (nt1^.val, nt2^.val) of
+        -- If both are applications, it suffices to directly check names and arguments
+        (NT_App _ _ _, NT_App _ _ _) -> return $ nt1 `aeq` nt2
+
+        -- Otherwise we unfold one of them and continue
+        -- Since we don't have mutually recursive types, this should terminate
+        (NT_App p@(PRes (PDot _ n)) is as, _) ->
+            resolveNameTypeApp p is as >>= (`subNameType` nt2)
+
+        (_, NT_App p@(PRes (PDot _ n)) is as) ->
+            resolveNameTypeApp p is as >>= (nt1 `subNameType`)
+
+        _ -> do
+            res <- withPushLog $ case (nt1^.val, nt2^.val) of
+                    _ | nt1 `aeq` nt2 -> return True
+                    (NT_DH, NT_DH) -> return True
+                    (NT_Sig t1, NT_Sig t2) -> isSubtype t1 t2
+                    (NT_Nonce s1, NT_Nonce s2) -> return $ s1 == s2
+                    (NT_Enc t1, NT_Enc t2) -> isSubtype t1 t2
+                    (NT_StAEAD t1 xp1 pth1 xpat1, NT_StAEAD t2 xp2 pth2 xpat2) -> do
+                        b1 <- isSubtype t1 t2
+                        ((x, slf), p1) <- unbind xp1
+                        ((x', slf'), p2_) <- unbind xp2
+                        let p2 = subst x' (aeVar' x) $ subst slf' (aeVar' slf) $ p2_
+                        b2 <- withVars [(x, (ignore $ show x, Nothing, tGhost)), (slf, (ignore $ show slf, Nothing, tGhost))] $ decideProp $ p1 `pImpl` p2
+                        b3 <- return $ pth1 `aeq` pth2
+                        (z, pat1) <- unbind xpat1
+                        (w, pat2) <- unbind xpat2
+                        b4 <- withVars [(z, (ignore $ show z, Nothing, tGhost))] $ decideProp $ pat1 `pEq` (subst w (aeVar' z) pat2)
+                        return $ b1 && (b2 == Just True) && b3 && (b4 == Just True)
+                    (NT_KDF pos1 body1, NT_KDF pos2 body2) -> do
+                        (((sx, x), (sy, y), (sz, z)), bnds) <- unbind body1
+                        (((sx', x'), (sy', y'), (sz', z')), bnds') <- unbind body2
+                        withVars [(x, (ignore sx, Nothing, tGhost)), (y, (ignore sy, Nothing, tGhost)), (z, (ignore sz, Nothing, tGhost))] $ 
+                            if pos1 == pos2 && length bnds == length bnds' then go bnds (substs [(x', aeVar' x), (y', aeVar' y), (z', aeVar' z)] bnds') else return False
+                            where
+                                go :: [Bind [IdxVar] (Prop, [(KDFStrictness, NameType)])] -> 
+                                    [Bind [IdxVar] (Prop, [(KDFStrictness, NameType)])] -> 
+                                    Check Bool
+                                go [] [] = return True
+                                go (b1:xs) (b2:ys) = do
+                                    (is1, rest1) <- unbind b1
+                                    (is2, rest2_) <- unbind b2
+                                    bhere <- if length is1 == length is2 then do
+                                        let rest2 = substs (map (\(i1, i2) -> (i2, mkIVar i1)) (zip is1 is2)) rest2_
+                                        withIndices (map (\i -> (i, (ignore $ show i, IdxGhost))) is1) $ do
+                                            b1 <- decideProp $ pImpl (fst rest1) (fst rest2)
+                                            if (b1 == Just True) then do 
+                                                allM (zip (snd rest1) (snd rest2)) $ \(nt1, nt2) -> 
+                                                    if (fst nt1 == fst nt2) then subNameType (snd nt1) (snd nt2) else return False
+                                            else return False
+                                        else return False
+                                    if bhere then go xs ys else return False
+                    _ -> return False                                
+            return res
 
                                                          
 
@@ -1285,9 +1299,10 @@ checkDecl d cont = withSpan (d^.spanOf) $
           tds <- view $ curMod . nameTypeDefs
           assert ("Duplicate name type name: " ++ s) $ not $ member s tds
           (((is, ps), xs), nt) <- unbind bnt
-          withIndices (map (\i -> (i, (ignore $ show i, IdxSession))) is ++ map (\i -> (i, (ignore $ show i, IdxPId))) ps) $ do 
-                withVars (map (\x -> (x, (ignore $ show x, Nothing, tGhost))) xs) $ do
-                    checkNameType nt
+          local (over curNameTypeDef $ \_ -> Just (s, bnt)) $
+            withIndices (map (\i -> (i, (ignore $ show i, IdxSession))) is ++ map (\i -> (i, (ignore $ show i, IdxPId))) ps) $ do 
+                    withVars (map (\x -> (x, (ignore $ show x, Nothing, tGhost))) xs) $ do
+                        checkNameType nt
           local (over (curMod . nameTypeDefs) $ insert s bnt) $ cont
       DeclODH s b -> do
           ensureNoConcreteDefs
@@ -1379,10 +1394,10 @@ nameTypeUniform nt =
       NT_StAEAD _ _ _ _ -> return ()
       NT_Enc _ -> return ()
       NT_App p@(PRes (PDot _ n)) ps as -> do
-        cur_def <- view curNameDef
-        case cur_def of
+        nt_def <- view curNameTypeDef
+        case nt_def of
             Just (n', _) | n == n' ->
-            -- TODO: check that ps contains strictly increasing indices
+                -- TODO: check that ps contains strictly increasing indices
                 return ()
             _ -> resolveNameTypeApp p ps as >>= nameTypeUniform
       NT_MAC _ -> return ()
@@ -1462,10 +1477,11 @@ checkNoTopTy allowGhost t =
       _ -> return ()      
           
 
-
-
 checkNameType :: NameType -> Check ()
-checkNameType nt = withSpan (nt^.spanOf) $ 
+checkNameType = checkNameType' Nothing
+
+checkNameType' :: Maybe String -> NameType -> Check ()
+checkNameType' rec_nt nt = withSpan (nt^.spanOf) $ 
     case nt^.val of
       NT_DH -> return ()
       NT_Sig t -> do
@@ -1488,7 +1504,7 @@ checkNameType nt = withSpan (nt^.spanOf) $
                               not $ xself `elem` (toListOf fv p)
                       checkProp p
                       forM_ nts $ \(str, nt) -> do
-                          checkNameType nt
+                          checkNameType' rec_nt nt
                           nameTypeUniform nt
                       return $ mkExistsIdx ixs p 
               (_, b) <- SMT.smtTypingQuery "disjoint" $ SMT.disjointProps ps
@@ -1499,12 +1515,14 @@ checkNameType nt = withSpan (nt^.spanOf) $
         checkNoTopTy False t
         checkTyPubLen t
       NT_App p@(PRes (PDot _ n)) ps as -> do
-          cur_def <- view curNameDef
-          case cur_def of
+          nt_def <- view curNameTypeDef
+          case nt_def of
             Just (n', _) | n == n' ->
               -- TODO: check that ps contains strictly increasing indices
               return ()
-            _ -> resolveNameTypeApp p ps as >>= checkNameType
+            _ -> case rec_nt of
+                Just n' | n == n' -> return ()
+                _ -> resolveNameTypeApp p ps as >>= checkNameType' (Just n)
       NT_StAEAD t xsaad p ypat -> do
           checkTy t
           checkNoTopTy False t

--- a/src/Typing.hs
+++ b/src/Typing.hs
@@ -67,7 +67,7 @@ emptyEnv f = do
     m <- newIORef $ M.empty
     rs <- newIORef []
     memo <- mkMemoEntry 
-    return $ Env mempty mempty mempty Nothing f initDetFuncs (TcGhost False) mempty [(Nothing, emptyModBody ModConcrete)] mempty 
+    return $ Env mempty Nothing mempty mempty Nothing f initDetFuncs (TcGhost False) mempty [(Nothing, emptyModBody ModConcrete)] mempty 
         interpUserFunc r m [memo] mempty rs r' r'' (typeError') checkNameType normalizeTy normalizeProp decideProp Nothing [] False False def
 
 
@@ -984,7 +984,8 @@ addNameDef n (is1, is2) (nt, nls) k = do
               withSpan (nt^.spanOf) $ assert (show $ owlpretty "Indices on abstract and concrete def of name" <+> owlpretty n <+> owlpretty "do not match") $ (length is1 == length is1' && length is2 == length is2')
           _ -> typeError $ "Duplicate name: " ++ n
     withSpan (nt^.spanOf) $ assert (show $ owlpretty "Duplicate indices in definition: " <> owlpretty (is1 ++ is2)) $ UL.allUnique (is1 ++ is2)
-    withIndices (map (\i -> (i, (ignore $ show i, IdxSession))) is1 ++ map (\i -> (i, (ignore $ show i, IdxPId))) is2) $ do
+    withIndices (map (\i -> (i, (ignore $ show i, IdxSession))) is1 ++ map (\i -> (i, (ignore $ show i, IdxPId))) is2) $
+        local (over curNameDef $ \_ -> Just (n, bind (is1, is2) (BaseDef (nt, nls)))) $ do
             forM_ nls normLocality
             checkNameType nt
     local (over (curMod . nameDefs) $ insert n (bind (is1, is2) (BaseDef (nt, nls)))) $ k

--- a/tests/success/recursive_name.owl
+++ b/tests/success/recursive_name.owl
@@ -1,0 +1,12 @@
+name n<i> : nonce
+name k1<i> : enckey Name(n<succ(i)>)
+
+// Should fail parser
+// name k2<succ(i)> : nonce
+
+name k2<i> : enckey Name(k2<succ(i)>)
+
+name k3<i> : kdf {ikm info.
+    info == 0x01 -> nonce,
+    info == 0x02 -> k3<succ(i)> 
+}

--- a/tests/success/recursive_name.owl
+++ b/tests/success/recursive_name.owl
@@ -11,7 +11,7 @@ name k2<i> : enckey Name(k2<succ(i)>)
 
 nametype rec3<i> = kdf {ikm info.
     info == 0x01 -> nonce,
-    info == 0x02 -> rec3<succ(i)>
+    info == 0x02 -> strict rec3<succ(i)>
 }
 name k3<i> : rec3<i>
 

--- a/tests/success/recursive_name.owl
+++ b/tests/success/recursive_name.owl
@@ -7,7 +7,10 @@ name k1<i> : enckey Name(n<succ(i)>)
 // name k2<succ(i)> : nonce
 
 // TODO: do we want to allow this?
-name k2<i> : enckey Name(k2<succ(i)>)
+name k2<i>: enckey Name(k2<succ(i)>)
+
+// Should fail
+// name k3<i> : enckey Name(k3<i>)
 
 nametype rec3<i> = kdf {ikm info.
     info == 0x01 -> nonce,
@@ -15,16 +18,55 @@ nametype rec3<i> = kdf {ikm info.
 }
 name k3<i> : rec3<i>
 
-nametype rec4<i> = kdf {ikm info.
-    info == 0x01 -> nonce,
-    info == 0x02 -> kdf {ikm info.
-        info == 0x01 -> rec4<succ(i)>
-    }
-}
-name k4<i> : rec4<i>
+name a : DH @ alice
+name b : DH @ alice
+name data : nonce @ alice
 
-def derive<i>(k: Name(k3<i>)) @ alice : Unit
+nametype rec4<i> = kdf {ikm info.
+    info == 0x01 -> enckey Name(data),
+    // info == 0x02 -> strict kdf {ikm info.
+    //     info == 0x01 -> strict rec4<succ(i)>
+    // }
+    info == 0x02 -> strict rec4<succ(i)>
+}
+
+odh schedule : a, b -> {salt info.
+    info == 0x01 -> enckey Name(data),
+    info == 0x02 -> strict rec4<0>
+} 
+
+def pasta<i>(k: Name(k3<i>)) @ alice : Unit
     =
-    let k1 = kdf<1;;kdfkey;0>(k, 0x00, 0x02) in
-    let _ = kdf<0;;nonce;0>(k1, 0x00, 0x01) in
+    let k = kdf<1;;kdfkey;0>(k, 0x00, 0x02) in
+    let k = kdf<1;;kdfkey;0>(k, 0x00, 0x02) in
+    let k = kdf<1;;kdfkey;0>(k, 0x00, 0x02) in
+    let k = kdf<1;;kdfkey;0>(k, 0x00, 0x02) in
+    let _ = kdf<0;;nonce;0>(k, 0x00, 0x01) in
     ()
+
+def pasta2<i>(k_pre: Ghost, k: SecName(KDF<kdfkey; 0; rec3<i>>(k_pre, 0x00, 0x02))) @ alice
+    : SecName(KDF<kdfkey; 0; rec3<succ(i)>>(k, 0x00, 0x02))
+    = kdf<1;;kdfkey;0>(k, 0x00, 0x02)
+
+def pasta3<i>(k_pre: Ghost, k: SecName(KDF<kdfkey; 0; rec3<i>>(k_pre, 0x00, 0x02))) @ alice
+    : SecName(KDF<kdfkey; 0; rec3<succ(succ(i))>>(gkdf<kdfkey;0>(k, 0x00, 0x02), 0x00, 0x02))
+    =
+    let k = kdf<1;;kdfkey;0>(k, 0x00, 0x02) in
+    let k = kdf<1;;kdfkey;0>(k, 0x00, 0x02) in
+    k
+
+struct Ticket<i> {
+    k_pre: Ghost,
+    k: SecName(KDF<kdfkey; 0; rec4<i>>(k_pre, 0x00, 0x02))
+}
+
+def pasta4<i>(ticket: Option(Ticket<session i>)) @ alice
+    : Option(Ticket<session succ(i)>)
+    =
+    case ticket {
+        | Some ticket =>
+            parse ticket as Ticket<session i>(k_pre, k) in
+            let new_k = kdf<1;;kdfkey;0>(k, 0x00, 0x02) in
+            Some(Ticket<session succ(i)>(k, new_k))
+        | None => None()
+    }

--- a/tests/success/recursive_name.owl
+++ b/tests/success/recursive_name.owl
@@ -1,12 +1,30 @@
+locality alice
+
 name n<i> : nonce
 name k1<i> : enckey Name(n<succ(i)>)
 
-// Should fail parser
+// Parser should fail
 // name k2<succ(i)> : nonce
 
+// TODO: do we want to allow this?
 name k2<i> : enckey Name(k2<succ(i)>)
 
-name k3<i> : kdf {ikm info.
+nametype rec3<i> = kdf {ikm info.
     info == 0x01 -> nonce,
-    info == 0x02 -> k3<succ(i)> 
+    info == 0x02 -> rec3<succ(i)>
 }
+name k3<i> : rec3<i>
+
+nametype rec4<i> = kdf {ikm info.
+    info == 0x01 -> nonce,
+    info == 0x02 -> kdf {ikm info.
+        info == 0x01 -> rec4<succ(i)>
+    }
+}
+name k4<i> : rec4<i>
+
+def derive<i>(k: Name(k3<i>)) @ alice : Unit
+    =
+    let k1 = kdf<1;;kdfkey;0>(k, 0x00, 0x02) in
+    let _ = kdf<0;;nonce;0>(k1, 0x00, 0x01) in
+    ()


### PR DESCRIPTION
Hello! As we discussed, I added support for recursive name and nametype definitions by (co)induction on the session index, and now a session index has an additional natural number like structure.

Examples:
```
name k<i>: enckey Name(k<succ(i)>)

nametype rec<i> = kdf {ikm info.
    info == 0x01 -> nonce,
    info == 0x02 -> strict kdf {
        info == 0x01 -> strict rec<succ(i)>
    }
}
name k: rec<0>
```
More examples can be found in `tests/success/recursive_name.owl`.
All current test cases are passing.

Some potential issues:
- I'm not sure about the change on subtyping. Previously names are fully unfolded in the subtyping check `subNameType`. I made it so that we don't unfold recursive name types initially in `normalizeNameType`, but instead unfold as needed when we actually comparing two types in `subNameType`. But I'm not completely sure if that interacts with other types well.
- No support for mutual recursion yet

Thanks in advance for any comments!