### PR TITLE
Add refinement for Some? and None? in case and SMT

### DIFF
--- a/prelude.smt2
+++ b/prelude.smt2
@@ -161,6 +161,9 @@
 (define-fun TestEnumTag ((x Int) (y Bits)) Bits
     (eq (Prefix y 2) (EnumTag x)))
 
+(define-fun None? ((x Bits)) Bits (TestEnumTag 0 x))
+(define-fun Some? ((x Bits)) Bits (TestEnumTag 1 x))
+
 (declare-sort Name)
 (declare-fun ValueOf (Name) Bits)
 (declare-fun TName (Name) Type)

--- a/src/SMT.hs
+++ b/src/SMT.hs
@@ -279,7 +279,7 @@ lookupIndex x xs = go 0 xs
                            | otherwise = go (i + 1) ys
 
 builtInSMTFuncs :: [String]
-builtInSMTFuncs = ["length", "eq", "plus", "mult", "UNIT", "true", "false", "andb", "concat", "zero", "dh_combine", "dhpk", "is_group_elem", "crh", "xor"]
+builtInSMTFuncs = ["length", "eq", "plus", "mult", "UNIT", "true", "false", "andb", "concat", "zero", "dh_combine", "dhpk", "is_group_elem", "crh", "xor", "Some?", "None?"]
 
 
 setupFunc :: (ResolvedPath, Int) -> Sym ()

--- a/src/Typing.hs
+++ b/src/Typing.hs
@@ -2317,21 +2317,15 @@ checkExpr ot e = withSpan (e^.spanOf) $ pushRoutine ("checkExpr") $ local (set e
           forM_ cases $ \(c, cse) -> do 
               let (Just otcase) = lookup c tcases
               case (otcase, cse) of
-                (Nothing, Left ek) -> 
-                    case c of
-                      "None" -> checkExpr (Just retT) ek >>= \_ -> return ()
-                      "Some" -> checkExpr (Just retT) ek >>= \_ -> return ()
-                      _ -> do 
-                          x <- freshVar
-                          _ <- withVars [(s2n x, (ignore $ show x, Nothing, tLemma $ pEq aeTrue $ aeApp (PRes $ PDot enumPath $ c ++ "?") [] [e1_a]))] $ checkExpr (Just retT) ek
-                          return ()
+                (Nothing, Left ek) -> do
+                    x <- freshVar
+                    _ <- withVars [(s2n x, (ignore $ show x, Nothing, tLemma $ pEq aeTrue $ aeApp (PRes $ PDot enumPath $ c ++ "?") [] [e1_a]))] $
+                        checkExpr (Just retT) ek
+                    return ()
                 (Just t1, Right (xs, bnd)) -> do
                     (x, k) <- unbind bnd
                     xt <- normalizeTy =<< computeEnumDataType tEnum t t1 caseNameArities c
-                    let xt_refined = case c of
-                                       "Some" -> xt
-                                       "None" -> xt
-                                       _ -> tRefined xt "._" $ pEq aeTrue $ aeApp (PRes $ PDot enumPath $ c ++ "?") [] [e1_a]
+                    let xt_refined = tRefined xt "._" $ pEq aeTrue $ aeApp (PRes $ PDot enumPath $ c ++ "?") [] [e1_a]
                     _ <- withVars [(x, (xs, Nothing, xt_refined))] $ checkExpr (Just retT) k
                     return ()
                 _ -> do

--- a/tests/success/option_refine.owl
+++ b/tests/success/option_refine.owl
@@ -1,0 +1,15 @@
+locality alice
+
+name secret: nonce @ alice
+
+def test1(x: Option(Data<adv>)) @ alice :
+    if Some?(x) then Option(Data<adv>) else Unit
+    =
+    case x {
+        | Some y => Some(y)
+        | None => ()
+    }
+
+def test2(x: Option(Data<adv>)) @ alice :
+    if Some?(x) /\ None?(x) then Name(secret) else Unit
+    = ()


### PR DESCRIPTION
We are missing some lemmas for `None?`/`Some?` after `case` on `Option`.

Is it ok to define `None?` and `Some?` in SMT with `TestEnumTag`? Otherwise we cannot prove that they are disjoint.

All tests are passing.